### PR TITLE
rendering definitions via SPARQL results in Guided tour 

### DIFF
--- a/packages/api/src/lib/flams.ts
+++ b/packages/api/src/lib/flams.ts
@@ -270,7 +270,7 @@ export const getSparqlQueryForLoRelationToDimAndConceptPair = (uri: string) => {
                         FILTER(CONTAINS(STR(?learningObject), "${encodeURI(uri)}")).
                         VALUES ?relation {
                                 ulo:precondition
-                                ulo:objective 
+                                ulo:objective
                                 }
                       }
                 GROUP BY ?learningObject ?relation ?obj1 `;
@@ -296,7 +296,7 @@ export const getSparqlQueryForLoRelationToNonDimConcept = (uri: string) => {
                                    ulo:specifies
                                    ulo:defines
                                    ulo:example-for
-                                   } 
+                                   }
                               }`;
   return query;
 };
@@ -452,7 +452,7 @@ WHERE {
     )
   VALUES ?relation {
           ${relationConditions}
-        } 
+        }
     ?lo rdf:type ?type .
       FILTER(?type IN (${loTypesConditions})).
       ${loStringFilter}
@@ -462,4 +462,15 @@ WHERE {
 `;
 
   return query;
+}
+
+export function getSparlQueryForDefinition(uri: string) {
+  return `
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX ulo: <http://mathhub.info/ulo#>
+        SELECT DISTINCT ?loname WHERE {
+  ?loname rdf:type ulo:definition .
+  ?loname ulo:defines <${uri}> .
+}
+  `;
 }

--- a/packages/stex-react-renderer/src/lib/TourDisplay.tsx
+++ b/packages/stex-react-renderer/src/lib/TourDisplay.tsx
@@ -11,6 +11,8 @@ import {
   getUriSmileys,
   SmileyCognitiveValues,
   smileyToLevel,
+  getQueryResults,
+  getSparlQueryForDefinition,
 } from '@stex-react/api';
 import { shouldUseDrawer, simpleHash } from '@stex-react/utils';
 import { useRouter } from 'next/router';
@@ -23,6 +25,7 @@ import { useOnScreen } from './useOnScreen';
 
 const NAV_MENU_ID = 'list-container';
 const EXPANSION_BOX_ID = 'expansion-box';
+
 
 export interface TourItem {
   uri: string;
@@ -143,12 +146,25 @@ function TourItemDisplay({
   onHideTemp: () => void;
   addToTempShowUri: (uri: string) => void;
 }) {
+
+  const [definitionUri, setDefinitionUri] = useState('https%3A%2F%2Fmathhub.info%3Fa%3Dsmglom%2Fai%26p%3Dmod%26d%3Dagent%26l%3Den%26e%3Ddefinition');
   const t = getLocaleObject(useRouter());
   const ref = useRef();
   const isVisible = useOnScreen(ref);
   useEffect(() => {
     visibilityUpdate(isVisible);
   }, [isVisible]);
+
+ useEffect(() => {
+async function fetchDefinition(uri: string) {
+const query = getSparlQueryForDefinition(uri);
+const results = await getQueryResults(query);
+console.log('Definition query results:', results);
+setDefinitionUri(uri)
+}
+fetchDefinition(item.uri)
+}, [item]);
+
 
   return (
     <Box id={expandedItemId(item)} maxWidth="600px" width="100%" ref={ref}>
@@ -197,6 +213,7 @@ function TourItemDisplay({
         />*/}
         //TODO ALEA4-G2
         {/* <FTMLFragment key={item.uri} fragment={{ uri: item.uri }} /> */}
+        <FTMLFragment key={definitionUri} fragment={{ type: 'FromBackend', uri: definitionUri }} />
       </Box>
 
       <Divider />
@@ -427,6 +444,8 @@ export function TourDisplay({
   const [understoodUri, setUnderstoodUriList] = useState([] as string[]);
   const [tempShowUri, setTempShowUri] = useState([] as string[]);
 
+  // const [sparqlResults, setSparqlResults] = useState<string[]>([]);
+
   async function buildDependencyTree(
     rootUri: string,
     maxDepth = 3,
@@ -480,6 +499,25 @@ export function TourDisplay({
       console.error('Failed to fetch and process tour items:', error);
     }
   }
+
+
+  //
+  // https://mathhub.info?a=smglom/ai&p=mod&m=agent&s=agent
+  // useEffect(() => {
+  //   async function runSparqlQuery() {
+
+  //     try {
+  //       const data = await getQueryResults(query);
+  //       const bindings = data?.results?.bindings?.map((b: any) => b['loname'].value) ?? [];
+  //       setSparqlResults(bindings);
+  //     } catch (error) {
+  //       console.error('SPARQL query failed:', error);
+  //     }
+  //   }
+
+  //   runSparqlQuery();
+  // }, []);
+  // //
 
   useEffect(() => {
     if (!tourId?.length) return;
@@ -564,6 +602,15 @@ export function TourDisplay({
               }}
             />
           ))}
+
+          {/* {sparqlResults.length > 0 && (
+            <Box mt={3} p={2} border="1px solid #ccc" borderRadius="8px">
+              <h4>SPARQL Results:</h4>
+              {sparqlResults.map((res, idx) => (
+                <div key={idx}>{res}</div>
+              ))}
+            </Box>
+          )} */}
         </Box>
       </Box>
     </LayoutWithFixedMenu>


### PR DESCRIPTION
Updated TourDisplay.tsx to fetch SPARQL results and render them using FTMLFragment, and added getSparlQueryForDefinition(uri) utility in flames.ts for building definition queries.
